### PR TITLE
fix/inputs: new vars format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,15 +21,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: release
-        uses: o0th/action-create-release@v0.0.5
+        uses: o0th/action-create-release@v0.1.0
 
       - uses: ./
         with:
           input-file: README.template.md
           output-file: README.md
           vars: |
-            {{version}} = ${{ steps.release.outputs.version }}
-            {{name}} = {{name}}
+            version = ${{ steps.release.outputs.version }}
 
       - run: |
           git diff

--- a/README.template.md
+++ b/README.template.md
@@ -29,5 +29,5 @@ jobs:
           input-file: README.template.md
           output-file: README.md
           vars: |
-            {{name}} = World!
+            name = World!
 ```

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const input = core.getInput('input-file')
 const output = core.getInput('output-file') ?? input
 const vars = core.getInput('vars').split('\n')
 
-const regex = /{{(?<key>.*)}}[ ]*=[ ]*(?<value>.*)/
+const regex = /(?<key>[^ =]*) ?= ?(?<value>[^\n]*)\n?/
 const options = vars.reduce((accumulator, variable) => {
   const matches = variable.match(regex)
   const { key, value } = matches.groups

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 import fs from 'node:fs'
 
 import mustache from 'mustache'
-mustache.escape = (text) => text
-
 import core from '@actions/core'
 
 const input = core.getInput('input-file')

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "action-mustache-me",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-mustache-me",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "action-mustache-me",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "action-mustache-me",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Instead of using

```yaml
          vars: |
            {{name}} = World!
```

Now we use

```yaml
          vars: |
            name = World!
```

This will prevent escaping.